### PR TITLE
Add missing dependency PySide2 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 matplotlib
 PySimpleGUIQt
 pyqt5
+PySide2


### PR DESCRIPTION
We noticed after installing the dependencies with
`$ pip install -r requirements.txt`
that in *nohup.out* there appeared error messages
`
Traceback (most recent call last):
  File "/path/to/repo/time_tracker/time_tracker.py", line 1, in <module>
    import PySimpleGUIQt as sg
  File "/path/to/venv/time_tracker/lib/python3.7/site-packages/PySimpleGUIQt/__init__.py", line 2, in <module>
    from .PySimpleGUIQt import *
  File "/path/to/venv/time_tracker/lib/python3.7/site-packages/PySimpleGUIQt/PySimpleGUIQt.py", line 22, in <module>
    from PySide2.QtWidgets import QApplication, QLabel, QWidget, QLineEdit, QComboBox, QFormLayout, QVBoxLayout, QHBoxLayout, QListWidget, QDial, QTableWidget
ModuleNotFoundError: No module named 'PySide2'
`
so we added *PySide2* to the requirements file.