### PR TITLE
Add a config entry for the amount of days to create the report for

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "editor": "kate {LOG_FILE}",
     "report": "konsole --hide-menubar -e \"/bin/bash -c '{PY_BIN} report_generator.py; read'\"",
     "report_only_visual": "{PY_BIN} report_generator.py",
+    "report_days": 14,
     "default_icon": "icons/black/23F1.png",
     "use_utc": true,
     "labels": [

--- a/report_generator.py
+++ b/report_generator.py
@@ -20,7 +20,7 @@ df = pandas.read_csv(log_file, parse_dates=[0], index_col=0)
 df = df.tz_localize("UTC").tz_convert("Europe/Berlin")
 
 # display only last two weeks of records
-cond = (df.index >= df.index.max() - pandas.Timedelta(days=14))
+cond = (df.index >= df.index.max() - pandas.Timedelta(days=config["report_days"]))
 df = df[cond]
 
 # calculate duration


### PR DESCRIPTION
After holidays it is sometimes necessary to increase the number of days which are shown in the report. We introduced a setting in the config file to handle that.