### PR TITLE
Extract the reading of the config file to reuse the code

### DIFF
--- a/read_config.py
+++ b/read_config.py
@@ -1,0 +1,13 @@
+import json
+
+
+def get_config():
+    """Read config file config.json
+
+    Returns
+    -------
+    dict
+        key-value pairs contained in config.json
+    """
+    with open("config.json", "r") as f:
+        return json.load(f)

--- a/report_generator.py
+++ b/report_generator.py
@@ -3,14 +3,15 @@ import numpy
 import pandas
 import json
 from pandas.plotting import register_matplotlib_converters
+
+from read_config import get_config
+
 register_matplotlib_converters()
 
 import matplotlib.pyplot as plt
 
 # read config file
-f = open("config.json", "r")
-config = json.load(f)
-f.close()
+config = get_config()
 
 # log file location
 log_file = os.path.expanduser(config["log_file"])

--- a/report_generator.py
+++ b/report_generator.py
@@ -1,7 +1,7 @@
 import os
+
 import numpy
 import pandas
-import json
 from pandas.plotting import register_matplotlib_converters
 
 from read_config import get_config

--- a/time_tracker.py
+++ b/time_tracker.py
@@ -7,9 +7,9 @@ import json
 import shlex
 
 # read config file
-f = open("config.json", "r")
-config = json.load(f)
-f.close()
+from read_config import get_config
+
+config = get_config()
 
 # log file location
 log_file = os.path.expanduser(config["log_file"])

--- a/time_tracker.py
+++ b/time_tracker.py
@@ -1,10 +1,10 @@
-import PySimpleGUIQt as sg
-import os
-import sys
 import datetime
-import subprocess
-import json
+import os
 import shlex
+import subprocess
+import sys
+
+import PySimpleGUIQt as sg
 
 # read config file
 from read_config import get_config


### PR DESCRIPTION
When I was preparing for another feature, I noticed the not ideal file management for reading the config. See the [official docs for details](https://docs.python.org/3/tutorial/inputoutput.html#reading-and-writing-files). With this PR I suggest to follow the official pattern and reduce redundancy.

Actually we intended to send a PR for the mentioned feature, but this is not possible yet, since it is based on this PR's branch. You can find it [in our fork](https://github.com/BjoernLudwigPTB/time_tracker/pull/2) if you are already interested. We will send it as soon, as this PR is finalized and merged.